### PR TITLE
Fix batch production edit losing previous details

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,2 +1,4 @@
 .env
+node_modules/
+.phpunit.result.cache
 

--- a/app/Http/Controllers/BatchProductionController.php
+++ b/app/Http/Controllers/BatchProductionController.php
@@ -360,10 +360,20 @@ class BatchProductionController extends Controller
           ->get();
 
         // Ambil detail batch production input
+        // Gunakan select terpisah agar kolom tidak saling menimpa ketika nama kolom sama
         $details = DB::table('batchproduction_input')
-        ->leftJoin('inventory', 'batchproduction_input.inventory_id', '=', 'inventory.id')
-        ->leftJoin('detail_penerimaan', 'batchproduction_input.id_detail_penerimaan', '=', 'detail_penerimaan.id_detail_penerimaan')
-        ->where('batchproduction_id', $decodedId)->get();
+            ->leftJoin('inventory', 'batchproduction_input.inventory_id', '=', 'inventory.id')
+            ->leftJoin('detail_penerimaan', 'batchproduction_input.id_detail_penerimaan', '=', 'detail_penerimaan.id_detail_penerimaan')
+            ->where('batchproduction_id', $decodedId)
+            ->select([
+                'batchproduction_input.*',
+                DB::raw('batchproduction_input.id as detail_id'),
+                DB::raw('batchproduction_input.catatan as detail_catatan'),
+                DB::raw('inventory.catatan as inventory_catatan'),
+                'detail_penerimaan.id_batch',
+                'detail_penerimaan.jenis_kemasan',
+            ])
+            ->get();
 
 
 

--- a/resources/views/batch-productions/edit.blade.php
+++ b/resources/views/batch-productions/edit.blade.php
@@ -299,7 +299,7 @@
                                                                 <tr class="detail-row">
                                                                     <td>
                                                                         <input type="hidden" name="detail_ids[]"
-                                                                            value="{{ $detail->id }}">
+                                                                            value="{{ $detail->detail_id }}">
 
 
                                                                         <input type="text"
@@ -323,7 +323,7 @@
                                                                         <input type="text"
                                                                             class="form-control inventory-display"
                                                                             placeholder="Pilih Inventory" readonly
-                                                                            value="{{ $detail->catatan }}">
+                                                                            value="{{ $detail->inventory_catatan }}">
 
                                                                         <!-- Modal -->
 
@@ -367,7 +367,7 @@
                                                                             required>
                                                                     </td>
                                                                     <td>
-                                                                        <textarea name="catatan_detail[]" class="form-control" rows="2">{{ old('catatan_detail.' . $index, $detail->catatan) }}</textarea>
+                                                                        <textarea name="catatan_detail[]" class="form-control" rows="2">{{ old('catatan_detail.' . $index, $detail->detail_catatan) }}</textarea>
                                                                     </td>
                                                                     <td class="text-center">
                                                                         <button type="button"


### PR DESCRIPTION
## Summary
- ensure batch production detail query uses explicit aliases to avoid column overwriting
- display correct inventory notes and detail ids in edit view
- ignore Node.js modules and phpunit cache

## Testing
- `./vendor/bin/phpunit` *(fails: Expected response status code [200] but received 302)*

------
https://chatgpt.com/codex/tasks/task_e_68a1894c8d8483268420bb7e39055a79